### PR TITLE
Fix typo with password_reset_required

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -63,7 +63,7 @@ module "iam_user" {
 
   # The following is dependent on whether a PGP key has been set
   create_iam_user_login_profile = length(each.value) > 0 ? true : false
-  password_reset_required       = length(each.value) > 0 ? true : false
+  password_reset_required       = length(each.value) < 0 ? true : false
 }
 
 # AWS IAM Policy Document for Force MFA, as taken from:


### PR DESCRIPTION
This PR:
- Fixes a typo with the ternary being inverted on `password_reset_required` for users who set PGP keys