### PR TITLE
Fix issue with for loop not knowing a state

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,7 @@ module "iam_assumable_roles" {
 
   # Allow created users to assume these roles
   trusted_role_arns = [
-    for superadmin in keys(local.superadmin_users) : module.iam_user[superadmin].this_iam_user_arn
+    for user in module.iam_user : user.this_iam_user_arn
   ]
 }
 
@@ -63,7 +63,7 @@ module "iam_group_admins_with_policies" {
   name    = "superadmins"
 
   group_users = [
-    for superadmin in keys(local.superadmin_users) : module.iam_user[superadmin].this_iam_user_name
+    for user in module.iam_user : user.this_iam_user_name
   ]
 
   custom_group_policy_arns = [


### PR DESCRIPTION
This PR:
- Fixes an issue where the previous `for` loop couldn't reference a created `module.iam_user` as its state was unknown due to it referencing a local variable

This now allows a reference to created IAM users rather than a local variable.