### PR TITLE
Add a note about onboarding new superadmins

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ module "iam" {
 ## Outputs
 | Name                 | Description                                                      | Sensitive |
 |----------------------|------------------------------------------------------------------|-----------|
-| superadmin_passwords | PGP-encrypted passwords for IAM users, if a pgp_key is specified | Yes       |
+| superadmin_passwords | PGP-encrypted passwords for IAM users, if a pgp_key is specified | yes       |
+
+## First-sign in and changing a password
+The included force_mfa IAM policy doesn't allow a user to change their password without MFA enabled. When onboarding a new superadmin,
+they will need to configure MFA before logging in for the first time.
 
 ## Looking for issues?
 If you're looking to raise an issue with this module, please create a new issue in the [Modernisation Platform repository](https://github.com/ministryofjustice/modernisation-platform/issues).

--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,7 @@ module "iam_account" {
   source        = "terraform-aws-modules/iam/aws//modules/iam-account"
   version       = "~> 2.0"
   account_alias = var.account_alias
+
   # Password policy rules
   allow_users_to_change_password = true
   create_account_password_policy = true
@@ -55,6 +56,8 @@ module "iam_assumable_roles" {
   trusted_role_arns = [
     for user in module.iam_user : user.this_iam_user_arn
   ]
+
+  depends_on = [module.iam_user]
 }
 
 # Attach created users to a AWS IAM group, with several policies
@@ -98,7 +101,7 @@ module "iam_user" {
   password_reset_required       = length(each.value) < 0 ? true : false
 }
 
-# Allow users to assume roles
+# Allow users to assume roles if MFA enabled
 data "aws_iam_policy_document" "assume_role" {
   statement {
     sid    = "AssumeRole"


### PR DESCRIPTION
This adds a note about MFA and a user's first password change; alongside fixes a `depends_on` declaration.