### PR TITLE
Fix versions and add output description

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -5,4 +5,5 @@ output "superadmin_passwords" {
     user.this_iam_user_name => user.this_iam_user_login_profile_encrypted_password
     if length(user.pgp_key) > 0
   }
+  description = "Map of users and PGP-encrypted passwords, e.g. { bob: 'abcdefg123456' }"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,8 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 3.20.0"
     }
   }
 }


### PR DESCRIPTION
This PR fixes provider versions to use the correct minimum `aws` provider version.

It also adds a missing output description.

Once this is merged we can release v1.0.0 of this, so we can pin it as part of ministryofjustice/modernisation-platform#72.