### PR TITLE
Change PGP encrypted passwords from sensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ module "iam" {
 ## Outputs
 | Name                 | Description                                                      | Sensitive |
 |----------------------|------------------------------------------------------------------|-----------|
-| superadmin_passwords | PGP-encrypted passwords for IAM users, if a pgp_key is specified | yes       |
+| superadmin_passwords | PGP-encrypted passwords for IAM users, if a pgp_key is specified | no        |
 
 ## First-sign in and changing a password
 The included force_mfa IAM policy doesn't allow a user to change their password without MFA enabled. When onboarding a new superadmin,

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,4 @@
 output "superadmin_passwords" {
-  sensitive = true
   value = {
     for user in module.iam_user :
     user.this_iam_user_name => user.this_iam_user_login_profile_encrypted_password


### PR DESCRIPTION
The user passwords for users with PGP keys do not need to be sensitive,
they are PGP encrypted and only used for first time login.