### PR TITLE
Add new starter to AWS superadmins

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,7 @@
 locals {
   superadmin_users = {
     "david.elliott"       = "keybase:davidkelliott"
+    "david.sibley"        = ""
     "don.masters"         = ""
     "ewa.stempel"         = ""
     "fasih.rehman"        = "keybase:fasih_rehman"


### PR DESCRIPTION
Adds david.sibley to local containing superadmin_users for AWS accounts.