### PR TITLE
updated minimum terraform/provider versions

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = "~> 1.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.20.0"
+      version = "~> 4.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = "~> 1.0"
+  required_version = ">= 1.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = ">= 4.0"
     }
   }
 }


### PR DESCRIPTION
Following some recent dependabot PRs the minimum versions for both the Terraform application and AWS Provider have been incremented to prevent any untoward behaviour