### PR TITLE
AWS Provider 5.0 upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .terraform.lock.hcl
 *.tfstate
 .DS_Store
+.idea

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
       version = "~> 5.0"
     }
     time = {
-      source = "hashicorp/time"
+      source  = "hashicorp/time"
       version = "~> 0.9"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -1,9 +1,13 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = "~> 1.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = "~> 5.0"
+    }
+    time = {
+      source = "hashicorp/time"
+      version = "~> 0.9"
     }
   }
 }


### PR DESCRIPTION
Bumps version constraint to ~> 5.0.
Add missing `time` provider
Related to https://github.com/ministryofjustice/modernisation-platform/issues/4173