### PR TITLE
Fix SCA workflow permissions

### DIFF
--- a/.github/workflows/software-composition-analysis.yml
+++ b/.github/workflows/software-composition-analysis.yml
@@ -19,7 +19,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-      security-events: read
+      security-events: write
 
     steps:
       - name: Run SCA


### PR DESCRIPTION
Fixing permissions for failing SCA run - https://github.com/ministryofjustice/modernisation-platform-terraform-iam-superadmins/actions/runs/24876084755/job/72832906695